### PR TITLE
Eetlijst query fix

### DIFF
--- a/eetlijst/templates/eetlijst/table.html
+++ b/eetlijst/templates/eetlijst/table.html
@@ -25,7 +25,7 @@
         <tr>
             <td></td>
             <td>Totaal</td>
-            <td class="uk-text-center">{{ total_balance }} </td>
+            <td class="uk-text-center">{# total_balance #} </td>
             {% for n, d in date_list.items %}
             <td class="days-table {% if d.2 == False %}uk-visible-large {% endif %}uk-text-center">{{ d.1|day_total }}</td>
             {% endfor %}

--- a/eetlijst/templates/eetlijst/table.html
+++ b/eetlijst/templates/eetlijst/table.html
@@ -25,7 +25,7 @@
         <tr>
             <td></td>
             <td>Totaal</td>
-            <td></td>
+            <td class="uk-text-center">{{ total_balance }} </td>
             {% for n, d in date_list.items %}
             <td class="days-table {% if d.2 == False %}uk-visible-large {% endif %}uk-text-center">{{ d.1|day_total }}</td>
             {% endfor %}
@@ -40,19 +40,33 @@
 
             <td class="names-table uk-hidden-small">{{ u }}{% if u.diet %} <i class="uk-icon-exclamation-circle uk-icon-hover" data-uk-tooltip="{pos:'right'}" title="{{ u.diet }}"></i>{% endif %}</td>
             <td class="names-table-small uk-visible-small uk-text-small">{{ u }}</td>
-            <td class="uk-text-center uk-hidden-small" style="width: 4em; background-color:rgba({{ u.balance|bal_color }});">{% if u.balance > 0 %}+{% endif %}{{ u.balance }}</td>
+            <td class="uk-text-center uk-hidden-small" style="width:4em;background-color:rgba( {{ u.balance|bal_color }} );"> {% if u.balance > 0 %}+{% endif %}{{ u.balance }}</td>
             <td class="uk-text-center uk-text-small uk-visible-small" style="width: 3em; padding: 4px; background-color:rgba({{ u.balance|bal_color }});">{% if u.balance > 0 %}+{% endif %}{{ u.balance }}</td>
-            {% for n, d in date_list.items %}
-                <td class="days-table {% if d.2 == False %}uk-visible-large {% endif %}uk-text-small uk-text-center"{% if d.3 == False %} style="background-color:rgba(187,187,221,0.5);"{% elif d.2 == True %} style="background-color:rgba(255,216,0,0.3);"{% endif %}>
-                    {% if not d.1|cost:u.user.id == 0 %}<span style="display: inline-block;">{{ d.1|cost:u.user.id }}</span>{% endif %}
-                    <span style="display: inline-block;">
-                    {% if not d.1|cost:u.user.id == 0 %}({% endif %}
-                    {% if d.1|is_cook:u.user.id %}<img src="/static/img/chefs_hat.png" alt="" style="{% if d.1|cost:u.user.id == 0 %}margin-top: -4px;{% else %}margin-top: -3px; width: 12px; height: 12px;{% endif %}" />{% endif %}
-                    {% if d.1|eating_with:u.user.id %}<i class="uk-icon-times{% if d.1|cost:u.user.id == 0 %} uk-icon-small{% endif %}"></i>{% if d.1|eating_with:u.user.id > 1 %}<span {% if not d.1|cost:u.user.id == 0 %}class="uk-text-small"{% endif %}>{{ d.1|eating_with:u.user.id }}</span>{% endif %}{% endif %}
-                    {% if not d.1|cost:u.user.id == 0 %}){% endif %}
-                    </span>
-                </td>
-            {% endfor %}
+
+                {% for n, d in date_list.items %}
+                    <td class="days-table {% if d.2 == False %}uk-visible-large {% endif %}uk-text-small uk-text-center"{% if d.3 == False %} style="background-color:rgba(187,187,221,0.5);"{% elif d.2 == True %} style="background-color:rgba(255,216,0,0.3);"{% endif %}>
+
+                    {# Implement dictionary lookup with tuple instead of query in template tag#}
+                    {% get_dict user_date_entries u.user.id d.1 as success %}
+
+                    {% if success != 0 %}
+                        {% if success.list_cost != None %}
+                        <span style="display: inline-block;"> {{ success.list_cost }} </span>
+                        {% endif %}
+                        <span style="display: inline-block;">
+                            {% if success.list_cost != None %} ( {% endif %}
+                            {% if success.list_cook != 0 %}<img src="/static/img/chefs_hat.png" alt="" style="{% if d.1|cost:u.user.id == 0 %}margin-top: -4px;{% else %}margin-top: -3px; width: 12px; height: 12px;{% endif %}" />{% endif %}
+                            {% if success.list_count > 0 %}
+                                <i class="uk-icon-times{% if success.list_cost == None %} uk-icon-small{% endif %}"></i>
+                                {% if success.list_count > 1 %}
+                                    <span {% if success.list_cost == None %} class="uk-text-small"{% endif %}>{{ success.list_count }}</span>
+                                {% endif %}
+                            {% endif %}
+                            {% if success.list_cost != None %} ) {% endif %}
+                        </span>
+                    {% endif %}
+                    </td>
+                {% endfor %}
         </tr>
         {% endfor %}
     </tbody>

--- a/eetlijst/templatetags/balance_color.py
+++ b/eetlijst/templatetags/balance_color.py
@@ -13,12 +13,12 @@ def bal_color(balance):
         if balance > 30:
             rgba_color = str(pos[0]) + ', ' + str(pos[1]) + ', ' + str(pos[2]) + ', ' + alpha
         else:
-            rgba_color = str(round(255 - balance*(255-pos[0])/30,0)) + ', ' + str(round(255 - balance*(255-pos[1])/30,0)) + ', ' + str(round(255 - balance*(255-pos[2])/30,0)) + ', ' + alpha
+            rgba_color = str(int(255 - balance*(255-pos[0])/30)) + ', ' + str(int(255 - balance*(255-pos[1])/30)) + ', ' + str(int(255 - balance*(255-pos[2])/30)) + ', ' + alpha
 
     else:
         if balance < -30:
             rgba_color = str(neg[0]) + ', ' + str(neg[1]) + ', ' + str(neg[2]) + ', ' + alpha
         else:
-            rgba_color = str(round(255 + balance*(255-neg[0])/30,0)) + ', ' + str(round(255 + balance*(255-neg[1])/30,0)) + ', ' + str(round(255 + balance*(255-neg[2])/30,0)) + ', ' + alpha
+            rgba_color = str(int(255 + balance*(255-neg[0])/30)) + ', ' + str(int(255 + balance*(255-neg[1])/30)) + ', ' + str(int(255 + balance*(255-neg[2])/30)) + ', ' + alpha
 
     return rgba_color

--- a/eetlijst/templatetags/date_data.py
+++ b/eetlijst/templatetags/date_data.py
@@ -2,6 +2,15 @@ from django.template.defaulttags import register
 from eetlijst.models import DateList, UserList
 import datetime as dt
 
+# retrieve value from 2D dictionary by tuple index
+@register.simple_tag
+def get_dict(dict, key_user, key_date):
+    tup_userdate = (key_user, key_date)
+    if dict.get(tup_userdate , 0 ):
+        return dict.get(tup_userdate , 0 )
+    else:
+        return 0
+
 # check if user is cook
 @register.filter
 def is_cook(date, id):
@@ -13,17 +22,6 @@ def is_cook(date, id):
         return 0
 
     return cook
-
-# check if user is eating with
-@register.filter
-def eating_with(date, id):
-    try:
-        eating = UserList.objects.get(user_id=id, list_date=date).list_count
-
-    except UserList.DoesNotExist:
-        return 0
-
-    return eating
 
 # get totals for each listed day
 @register.filter

--- a/eetlijst/tests.py
+++ b/eetlijst/tests.py
@@ -1,3 +1,18 @@
 from django.test import TestCase
+from django.template import Template,Context
+from templatetags import *
 
 # Create your tests here.
+class BalColorTagTest(TestCase):
+
+    TEMPLATE = Template("{% load balance_color %} {{ 32.14|bal_color }}")
+    TEMPLATE2 = Template("{% load balance_color %} {{ 15.48|bal_color }}")
+
+
+    def test_entry_shows_up(self):
+        rendered = self.TEMPLATE.render(Context({}))
+        rendered2 = self.TEMPLATE2.render(Context({}))
+        print rendered2
+
+        self.assertIn("110, 185, 110, 0.85",rendered)
+        self.assertIn("180, 219, 180, 0.85", rendered2)


### PR DESCRIPTION
Not only query fix, also minor fixes to saldo colour.
Addition/removal of template tags.
Added template-tag-test (super handy, the error was suddenly so easy to see!!). Add tests in future.

About saldo error:
- round(x,0) did not produce correct colour values ("200.0" etc.). Use int(x) instead ("200").
**Do wonder how this is not a problem on the live website.**